### PR TITLE
[PS-82] Use secret variables provided by GitHub Settings in the workflow

### DIFF
--- a/.github/workflows/update_trello_on_pr_update.yaml
+++ b/.github/workflows/update_trello_on_pr_update.yaml
@@ -21,3 +21,7 @@ jobs:
           STATUS="${{ github.event.pull_request.merged && 'Done' || 'Deleted' }}"
         fi
         bin/change_card_status.sh "$TICKET_NUMBER" "$STATUS"
+      env:
+        APIKey: ${{ secrets.TRELLO_API_KEY }}
+        APIToken: ${{ secrets.TRELLO_API_TOKEN }}
+        BoardID: ${{ secrets.TRELLO_BOARD_ID }}

--- a/bin/change_card_status.sh
+++ b/bin/change_card_status.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
-# set API 
-APIKey=""
-APIToken=""
-BoardID=""
+# Note: this script should run with the environmental variables such as APIKey, APIToken and BoardID.
 
 function find_card_id_of_ticket() {
   local ListID=$1


### PR DESCRIPTION
Changelog
====
- Uses secret variables provided by GitHub Settings in the workflow. 

Detailed Description
====
- Previously we used the hard-coded string in the code for API key & token but this may cause security risks. Since we added the strings to GitHub Settings Secret Variables, now we can use the secret variables as the environment variables for the workflow.