### PR TITLE
[PS-104] 1로만들기 2

### DIFF
--- a/solutions/minwoo/baekjoon/12852.1로만들기.py
+++ b/solutions/minwoo/baekjoon/12852.1로만들기.py
@@ -1,0 +1,21 @@
+from collections import deque
+q = deque()
+n = int(input())
+q.append((1,0,[1]))
+visit = [0]*(n+1)
+while q :
+    cur,cost, candidate = q.popleft()
+    visit[cur] = 1
+    if cur == n :
+        print(cost)
+        print(*candidate[::-1])
+        exit(0)
+    if cur*3 <= n and not visit[cur*3]:
+        q.append((cur*3,cost+1,candidate+[cur*3]))
+        visit[cur*3] = 1
+    if cur*2 <= n and not visit[cur*2]:
+        q.append((cur*2,cost+1,candidate+[cur*2]))
+        visit[cur*2] = 1
+    if cur+1 <= n and not visit[cur+1] :
+        q.append((cur+1,cost+1,candidate+[cur+1]))
+        visit[cur+1] = 1


### PR DESCRIPTION
Link
====
https://www.acmicpc.net/problem/12852

Approach
====  
DP, BFS로 풀수있음.
BFS로 돌리면, depth가 동일한 노드들먼저 pop 되므로, 먼저 방문된 노드는 방문하지않도록 가지치기를 할 수 있다.
(DP 문제 깎고있는 중에 푼 쉬운문제 이지만, 시간초과에 유의.) 
현재 내 로직은, 누적된 경로배열을 복사하고 끝에 새로운 요소를 추가하는데, 이녀석이 수행시간을 느리게함. 하나의 요소만 계속 추가하면서 추적할수있는방법이 있을까?

Time Complexity
====  
O(N) : 중복된 노드는 방문하지않으므로.

Space Complexity (optional)
====  

Detailed Description
====  