### PR TITLE
[PS-107] Add remove option for bearcard

### DIFF
--- a/bin/change_card_status.sh
+++ b/bin/change_card_status.sh
@@ -3,16 +3,18 @@
 # Note: this script should run with the environmental variables such as APIKey, APIToken and BoardID.
 
 function find_card_id_of_ticket() {
-  local ListID=$1
-  local TicketNumber=$2
+  local TicketNumber=$1
 
   # fetch all the cards in a given list
   all_cards=$(curl --silent --request GET \
-  --url "https://api.trello.com/1/lists/${ListID}/cards?key=${APIKey}&token=${APIToken}" \
+  --url "https://api.trello.com/1/boards/${BoardID}/cards?key=${APIKey}&token=${APIToken}" \
   --header 'Accept: application/json')
 
+  # return full card name where contains TicketNumber
+  echo "$all_cards" | jq -r --arg ticket "$TicketNumber" '.[] | select(.name | contains($ticket)) | .name' | tr -d '\r'
+
   # return card id where name contains TicketNumber
-  echo "$all_cards" | jq -r --arg ticket "$TicketNumber" '.[] | select(.name | contains($ticket)) | .id'
+  echo "$all_cards" | jq -r --arg ticket "$TicketNumber" '.[] | select(.name | contains($ticket)) | .id' | tr -d '\r'
 }
 
 function fetch_list_ids() {
@@ -25,28 +27,35 @@ function fetch_list_ids() {
 
     # fetch the ID of the Done list
     echo "$response" | jq -r --arg name "$list_name" '.[] | select(.name == $name).id'
-
-    # fetch all the list IDs
-    echo "$response" | jq -r '.[].id'
 }
 
-# Call function and capture output in an array
-IFS=$'\n' read -d '' -r -a output_array < <(fetch_list_ids "$2" && printf '\0')
-TargetListID="${output_array[0]}"
-list_ids=("${output_array[@]:1}")
+# fetch the target list id
+TargetListID=$(fetch_list_ids "$2")
 
 # find the card id of the ticket
-for id in "${list_ids[@]}"; do
-  target_card_id=$(find_card_id_of_ticket "$id" "$1")
+  IFS=$'\n' read -d '' -r -a output_array < <(find_card_id_of_ticket "$1" && printf '\0')
+  target_card_name="${output_array[0]}"
+  target_card_id="${output_array[1]}"
   if [ -n "$target_card_id" ]; then
+    ERROR_FILE=$(mktemp)
+
     # Update Trello
     curl --silent --request PUT \
       --url "https://api.trello.com/1/cards/${target_card_id}?key=${APIKey}&token=${APIToken}" \
       --header 'Accept: application/json' \
       --data "idList=$TargetListID&pos=top" \
-      -o /dev/null
+      -o /dev/null 2> "$ERROR_FILE"
+
+    if [ $? -eq 0 ]; then
+      echo "Successfully changed the status of the card \"$target_card_name\" into \"$2\"."
+    else
+      echo "Failed to change the status of the card \"$target_card_name\" into \"$2\": "
+      cat "$ERROR_FILE"
+    fi
+
+    rm "$ERROR_FILE"
     exit $?
   fi
-done
 
+echo "Failed to find the card containing the given string \"$1\""
 exit 1

--- a/bin/command/bearcard
+++ b/bin/command/bearcard
@@ -15,12 +15,14 @@ Usage: $SCRIPT_NAME [OPTIONS] "New card name"
 Options:
   -s, --setup-id    Set up assignee ID for automatic assignment of new cards
   -u, --update-key  Update Trello API key & token
+  -r, --remove      Remove a card that contains a given string
   -h, --help        Display this help message
 
 Examples:
   $SCRIPT_NAME "New card name"                   # Create a new card with name "New card name"
   $SCRIPT_NAME --setup-id "Kangwook"             # Set up assignee ID for automatic assignment
   $SCRIPT_NAME --update-key                      # Update Trello API key & token
+  $SCRIPT_NAME --remove "PS-106"                 # Remove a card that contains "PS-106"
 EOF
 }
 
@@ -37,6 +39,7 @@ if ! command -v jq &> /dev/null; then
     exit 1
 fi
 
+function check_config_file() {
 # Get values from config.json
 CONFIG_FILE=~/.${SCRIPT_NAME}/config.json
 if [[ ! -f $CONFIG_FILE ]]; then
@@ -48,19 +51,18 @@ APIKey=$(jq -r '.APIKey' $CONFIG_FILE)
 APIToken=$(jq -r '.APIToken' $CONFIG_FILE)
 BoardID=$(jq -r '.BoardID' $CONFIG_FILE)
 MemberID=$(cat ~/.${SCRIPT_NAME}/id 2>/dev/null)
+}
 
 function num_of_cards() {
-  local ListID=$1
-
   # fetch all the cards in a given list
   all_cards=$(curl --silent --request GET \
-  --url "https://api.trello.com/1/lists/${ListID}/cards?key=${APIKey}&token=${APIToken}" \
+  --url "https://api.trello.com/1/boards/${BoardID}/cards?key=${APIKey}&token=${APIToken}" \
   --header 'Accept: application/json')
 
   # check if response is an appropriate JSON
   echo "$response" | jq empty &>/dev/null
   if [ $? -ne 0 ]; then
-    echo "Error: Invalid JSON response for ${ListID}"
+    echo "Error: Invalid JSON response for all cards API"
     return 1
   fi
 
@@ -74,23 +76,16 @@ function fetch_list_ids() {
       --header 'Accept: application/json')
 
     # fetch the ID of the To Do list
-    echo "$response" | jq -r '.[] | select(.name == "To Do").id'
-
-    # fetch all the list IDs
-    echo "$response" | jq -r '.[].id'
+    echo "$response" | jq -r '.[] | select(.name == "To Do").id' | tr -d '\r'
 }
 
 function create_card() {
 # Call function and capture output in an array
 IFS=$'\n' read -d '' -r -a output_array < <(fetch_list_ids && printf '\0')
-TodoListID="${output_array[0]}"
-list_ids=("${output_array[@]:1}")
+TodoListID="${output_array}"
 
 # calculate the total number of the cards in the board
-total_number=1
-for id in "${list_ids[@]}"; do
-  total_number=$((total_number + $(num_of_cards $id)))
-done
+total_number=$(( 1 + $(num_of_cards) ))
 
 # encode URL using perl's sprintf
 message="[PS-$total_number] ${1}"
@@ -157,6 +152,17 @@ function setup_id() {
   fi
 }
 
+function remove_card() {
+  SCRIPT_PATH="$(realpath $0)"
+  PARENT_DIR="$(dirname $(dirname $SCRIPT_PATH))"
+
+  export APIKey APIToken BoardID
+  processed_str=$(echo "$1" | tr '[:lower:]' '[:upper:]')
+
+  echo "Trying to delete \"$processed_str\"..."
+  "$PARENT_DIR"/change_card_status.sh "$processed_str" "Deleted"
+}
+
 # Parse options and arguments
 while [[ $# -gt 0 ]]; do
   key="$1"
@@ -169,11 +175,17 @@ while [[ $# -gt 0 ]]; do
       update_key
       shift
       ;;
+    -r|--remove)
+      check_config_file
+      remove_card "$2"
+      shift 2
+      ;;
     -h|--help)
       usage
       exit 0
       ;;
     *) # Default case: If no option, then it's the card name
+      check_config_file
       create_card "$1"
       shift
       ;;

--- a/bin/command/bearcard
+++ b/bin/command/bearcard
@@ -15,7 +15,7 @@ Usage: $SCRIPT_NAME [OPTIONS] "New card name"
 Options:
   -s, --setup-id    Set up assignee ID for automatic assignment of new cards
   -u, --update-key  Update Trello API key & token
-  -r, --remove      Remove a card that contains a given string
+  -r, --remove      Remove a card that contains a given ticket number
   -h, --help        Display this help message
 
 Examples:
@@ -153,11 +153,11 @@ function setup_id() {
 }
 
 function remove_card() {
-  SCRIPT_PATH="$(realpath $0)"
-  PARENT_DIR="$(dirname $(dirname $SCRIPT_PATH))"
+  SCRIPT_PATH="$(cd "$(dirname "$0")"; pwd -P)"
+  PARENT_DIR="$(dirname $SCRIPT_PATH)"
 
   export APIKey APIToken BoardID
-  processed_str=$(echo "$1" | tr '[:lower:]' '[:upper:]')
+  processed_str=$(echo "$1" | tr '[:lower:]' '[:upper:]' | sed -nE '/^PS-[0-9]+$/p')
 
   echo "Trying to delete \"$processed_str\"..."
   "$PARENT_DIR"/change_card_status.sh "$processed_str" "Deleted"


### PR DESCRIPTION
Changelog
====
- Adds remove option for bearcard, to change the card status into "Deleted" using this command. 
  - This option uses the script in `bin/change_card_status.sh`, already used by the workflow, so the lines of change is very few.
- Adds the code to print the success/failure message for `bin/change_card_status.sh`, to show the result of the script clearly.
- Refactors `bin/change_card_status.sh` & `bearcard` to change the API endpoint when fetching all the cards. Previously it fetched all the list IDs first and then it found the card ID using the list IDs, since I didn't know the API endpoint that can fetch all the cards even though I don't know the specific list ID. Now it directly fetches all the cards not using the list IDs.
- Fixes a bug when running `bearcard --update-key` by introducing a function `check_config_file` in bearcard. Previously it didn't run properly since it needed the config file to run the code, due to my mistake.


Detailed Description
====
After this commit is merged, you can change the card status into "Deleted" by running `bearcard -r "Any string in the card name"` simply.