### PR TITLE
[PS-108] 프로그래머스 연속된 부분수열의 합

### DIFF
--- a/solutions/kangwook/programmers 연습문제/연속된부분수열의합.py
+++ b/solutions/kangwook/programmers 연습문제/연속된부분수열의합.py
@@ -1,0 +1,11 @@
+def solution(sequence, k):
+    s, now_sum = 0, 0
+    answer = []
+    for idx, num in enumerate(sequence):
+        now_sum += num
+        while now_sum > k:
+            now_sum -= sequence[s]
+            s += 1
+        if now_sum == k:
+            answer.append([s, idx])
+    return sorted(answer, key=lambda x: x[1] - x[0])[0]


### PR DESCRIPTION
Link
====
https://school.programmers.co.kr/learn/courses/30/lessons/178870

Approach
====  
투포인터

Time Complexity
====  
O(n)

Space Complexity (optional)
====  

Detailed Description
====  
- 처음에는 '구간의 합을 caching하고 이를 O(n)보다 빠른 시간 안에 가져와야 한다'라는 관점에서 접근해서 세그먼트 트리를 활용한 O(n log n)의 알고리즘을 떠올렸는데, 아무리 생각해도 레벨2보다는 구현 난이도가 높아보여 질문란을 훑어보니 투포인터라는 힌트를 발견해(;;) 순식간에 구현해보았다.
- 투포인터로 푸는 유형의 문제를 그렇게 많이 풀어보지 않아 이 문제처럼 투포인터로 쉽게 풀 수 있는 문제를 봐도 그렇게 쉽게 '투포인터!' 라는 생각이 잘 떠오르진 않는 것 같다. (최근에는 민우님의 [이 PR](https://github.com/Bear-Algorithm-Team/bearalgorithm/pull/52)에서 투포인터 문제를 풀어보긴 했다.) **1차원 배열을 처음부터 끝까지 훑는 문제**는 투포인터가 항상 최우선 고려 대상이라는 걸 꼭 기억해야겠다.