### PR TITLE
[PS-116] SW expert academy 17643. 로봇

### DIFF
--- a/solutions/kangwook/SWExpertAcademy/17643_로봇.py
+++ b/solutions/kangwook/SWExpertAcademy/17643_로봇.py
@@ -1,0 +1,40 @@
+
+T = int(input())
+for test_case in range(1, T + 1):
+    '''
+
+    x = x0 * 3^0 + x1 * 3^1 + ... + xn * 3^n
+    y = y0 * 3^0 + y1 * 3^1 + ... + yn * 3^n
+    
+    이 문제 핵심은 x_t가 0이면 y_t는 0이 아니어야 하고 반대도 마찬가지라는 거.
+    그냥 x, y를 3진법으로 변환해서 x_t, y_t 확인하면 되는 문제.
+
+    '''
+    
+    x, y = map(int, input().split())
+    
+    def check_if_digits_not_zero(x):
+        """
+        
+        매 루프마다 x를 3으로 나누고 그 나머지가 0 아니면 result에 (1 << t) 더한다.
+
+        근데 만약 2라면?
+        이건 현재 자리수가 -1이라는 의미.
+        그리고 이보다 윗자리수에 +1이 있다는 의미.
+
+        결과적으로 각 자릿수에 해당하는 x_t가 0인지 아닌지 여부가 1, 0으로 기록된 2진수가 리턴된다.
+        
+        """
+        result, t = 0, 0
+        while x:
+            digit = x % 3
+            result += int(digit != 0) << t
+            x //= 3
+            if digit == 2:
+                x += 1
+            t += 1
+        return result
+    
+    sum_digits = check_if_digits_not_zero(x) + check_if_digits_not_zero(y)
+    ans = "yes" if sum_digits & (sum_digits + 1) == 0 else "no" # 주어진 수가 2^n꼴인지 확인하는 비트연산식.
+    print(f"#{test_case} {ans}")


### PR DESCRIPTION
Link
====
https://swexpertacademy.com/main/code/problem/problemDetail.do?contestProbId=AYj_GSkqqNEDFASl&

Approach
====  
진법 변환, 비트연산

Time Complexity
====  
O(lg n): 진법변환으로 인한 반복횟수

Space Complexity (optional)
====  

Detailed Description
====  
- 결국 x좌표, y좌표는 3^t꼴 숫자들의 합으로 표현된다는 점에 주목해 수식을 써보면 진법변환이 문제의 키라는 것을 알 수 있다. 특히 핵심은 x의 표현식의 3^t의 계수인 x_t가 0이면 y의 표현식의 3^t의 계수인 y_t는 0이 아니어야 하고 반대도 마찬가지여야 한다는 점. 그래야 문제의 조건에 맞는 (x, y)이고 아니면 아니다. 둘 다 0이거나 둘 다 0이 아닌 상황은 일어날 수 없다.
- 이 문제는 3진법 문제지만, 이걸 "각 자릿수가 0이냐 아니냐"를 빠르고 깔끔하게 구현하는 데는 2진수 비트연산을 활용하는 것이 좋다. x와 y를 3진법으로 표현했을 때 각 자릿수가 0인지 아닌지를 1 또는 0으로 표현한 후 이 값을 서로 더했을 때 1111... 꼴이면 문제의 조건에 부합하는 (x, y)인 것이고 아니면 아닌 것. 
  - 일반적으로 어떤 수 x가 2^n 꼴인지 아닌지를 확인하는 가장 간편한 방법은 (x & (x - 1)) 값이 0인지 아닌지를 확인하는 것. x가 2^n꼴이면 비트로 표기하면 1000.. 꼴이고, x-1을 비트로 표기하면 111... 꼴이 될 것. 그러면 (x & (x - 1))는 0이 될 것. 2^n꼴 여부를 루프로 확인할 수도 있지만 이 정도 비트 연산식은 기억하기도 쉽고 쓸모도 많은 것 같다.