### PR TITLE
[PS-129] Release bearcard under the MIT License

### DIFF
--- a/bin/command/bearcard
+++ b/bin/command/bearcard
@@ -1,5 +1,27 @@
 #!/bin/bash
 
+# The MIT License (MIT)
+#
+# Copyright (c) 2023 Kangwook Lee, Minwoo Jung
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the “Software”), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 SCRIPT_NAME=$(basename "$0")
 
 function usage() {

--- a/bin/command/one-time-setup
+++ b/bin/command/one-time-setup
@@ -1,5 +1,27 @@
 #!/bin/bash
 
+# The MIT License (MIT)
+#
+# Copyright (c) 2023 Kangwook Lee, Minwoo Jung
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the “Software”), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 # Get the path of the current directory
 SCRIPT_PATH="$(cd "$(dirname "$0")"; pwd -P)"
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,3 +44,15 @@ bearcard --setup-id "Your Trello name"
 ```
 
 If you run this command with your Trello name, your Trello ID will be fetched and it will be saved in `~/.bearcard/id`. Then Trello will assign you as the assignee for the card automatically when you run bearcard.
+
+
+## License
+
+The files listed below are released under the MIT License:
+
+```
+bin/command/bearcard
+bin/command/one-time-setup
+```
+
+The rest of the files in this project are not covered by this license.


### PR DESCRIPTION
Changelog
====
- Releases beacard, a custom shell script for managing cards in Trello and one-time-setup, a custom shell script that helps using bearcard, under the MIT License, to allow others to use the code in compliance with the MIT License.


Detailed Description
====
### 1. MIT License에 관한 설명

MIT License는 오픈소스 라이선스 중 하나로, 배포자는 유한한 책임범위에서 소프트웨어를 자신의 저작권을 표시하며 오픈소스로 배포할 수 있고 제3자는 일정 조건 하에 다음 사항을 자유롭게 할 수 있습니다. 구체적 내용은 다음과 같습니다.

- **배포자의 책임범위**: 소프트웨어의 배포자는 소프트웨어에 어떠한 보증이나 책임이 없습니다.
- **사용 조건**: MIT License로 라이선스된 소프트웨어나 그 수정 버전을 재배포할 때, 저작권 표시 부분에 대한 수정 없이 마찬가지로 MIT License로 재배포해야 합니다.
- **재배포 및 수정 가능**: 소스코드 일부를 수정하여 재배포 할 수 있습니다.
- **상용 사용 허용**: MIT License로 라이선스된 소프트웨어를 별도의 라이선스 비용 없이 상용 제품에 포함하여 판매하는 것이 허용됩니다.

### 2. 소스코드를 MIT License로 배포하는 방법

- **라이선스 파일 추가**: 프로젝트의 소스코드를 모두 MIT License로 배포하는 경우에는 프로젝트의 루트 디렉토리에 `LICENSE` 또는 `LICENSE.md`라는 파일명으로 MIT 라이선스 텍스트를 추가합니다. (이 텍스트는 오픈소스 표준화 조직인 OSI에서 제공하는 [MIT License 텍스트](https://opensource.org/license/mit/)에서 가져올 수 있습니다.)

- **소스 파일에 헤더 추가**: 프로젝트 내 소스코드 중 일부만을 MIT License로 배포하는 경우, 해당 소스파일의 상단에 MIT License 텍스트를 추가하는 것으로 충분합니다.

- **프로젝트의 `README`에 라이선스 언급**(권장): 프로젝트의 `README.md` 등 메인 문서에 라이선스 정보를 명시합니다. *"이 프로젝트/프로젝트 내 다음 소스파일은 MIT License로 배포됩니다."* 정도의 문구면 충분합니다.


### 3. MIT License로 배포된 파일의 수정/재배포 방법

- 소스코드를 처음 MIT License로 배포하는 방법과 동일하게, 프로젝트의 루트 디렉토리나 해당 소스파일 상단에 MIT License 텍스트를 추가합니다. 단, 이때 저작권 표시 부분을 수정하지 말아야 합니다.

- 일부 수정한 내용이 있는 경우에는 수정된 파일도 같은 MIT License를 따라야 합니다. 이때, 수정했음을 의미하는 자신의 저작권 표시를 추가할 수 있습니다. 
