### PR TITLE
[PS-130] 20055 벨트위의 로봇

### DIFF
--- a/solutions/minwoo/baekjoon/20055 벨트위의로봇.py
+++ b/solutions/minwoo/baekjoon/20055 벨트위의로봇.py
@@ -1,0 +1,33 @@
+from collections import deque
+
+n,k = map(int,input().split())
+convey = deque(map(int,input().split()))
+robot = deque([0]*n)
+t = 1
+zero_cnt = 0
+while True :
+    #1 벨트, 로봇 회전.
+    convey.appendleft(convey.pop())
+    robot.pop()
+    robot.appendleft(0)
+    robot[-1] = 0
+     #내구도 zero 인 컨베이어
+    #2 먼저 올라간 순서대로 로봇 이동
+    for i in range(len(robot)-1,0,-1):
+        if convey[i] > 0 and robot[i-1] and not robot[i] :
+            robot[i-1],robot[i] = 0,1
+            convey[i]-=1 # 내구도 감소
+            if convey[i] == 0 :
+                zero_cnt +=1
+    #3 첫번째 컨베이어에 로봇 올리기.
+    if convey[0] > 0 :
+        robot[0] = 1
+        convey[0]-=1
+        if convey[0] == 0 :
+            zero_cnt +=1
+
+    if zero_cnt >=k :
+        break
+    t += 1
+print(t)
+


### PR DESCRIPTION
Link
====
https://www.acmicpc.net/problem/20055

Approach
====  
시뮬레이션
벨트의 맨끝과 처음이 연결된것은 큐로 구현해서 시간복잡도를 최소화 하려고 함..
정말 시키는대로 순서대로 하니까 통과됨.
최대한 시험장에서 디버깅 하기 편한 방식으로 짜려고 노력중인데 이 문제는 쉬운 옛날문제라서 함수로 나누지않았음

Time Complexity
====  
O(N*시뮬레이션 횟수)

Space Complexity (optional)
====  

Detailed Description
====  