### PR TITLE
[ps-135]인구이동

### DIFF
--- a/solutions/minwoo/baekjoon/16234 인구이동.py
+++ b/solutions/minwoo/baekjoon/16234 인구이동.py
@@ -1,0 +1,46 @@
+from collections import deque
+n,l,r = map(int,input().split())
+board = [list(map(int,input().split())) for _ in range(n)]
+t = 0
+
+def bfs(y,x): # return: 연합국가갯수, 총인구합, 해당위치좌표들
+    q = deque()
+    visit[y][x] = 1
+    q.append([y,x])
+    pos = [[y,x]]
+    population = board[y][x]
+    region = 1
+    while q :
+        y,x = q.popleft()
+        for dy,dx in ((0,1),(0,-1),(1,0),(-1,0)):
+            ny = y+dy
+            nx = x+dx
+            if 0<=ny<n and 0<=nx<n and not visit[ny][nx] and l<=abs(board[ny][nx] - board[y][x])<=r:
+                visit[ny][nx] = 1
+                q.append([ny,nx])
+                pos.append([ny,nx])
+                population+=board[ny][nx]
+                region+=1
+    return region,population,pos
+
+def move(move_info):
+    for _move_info in move_info :
+        region,population,pos = _move_info
+        carry = population // region # 배치시킬 인원
+        for y,x in pos :
+            board[y][x] = carry
+
+while True :
+    visit = [[0]*n for _ in range(n)]
+    move_info = []
+    for i in range(n):
+        for j in range(n):
+            if not visit[i][j]:
+                region,population,pos = bfs(i,j)
+                if region > 1 :
+                    move_info.append([region,population,pos])
+    if len(move_info) == 0 : # 국경이 모두 닫혀있을 때
+        break
+    move(move_info) # 인구이동 시작
+    t+=1
+print(t)


### PR DESCRIPTION
Link
====
https://www.acmicpc.net/problem/16234

Approach
====  
BFS 
BFS로 인구수 차이가 일정범위안에 있는 좌표들을 구하고, 한번에 인구이동을 진행한다.
처음푼다 생각하고 풀었는데 1년전 코드랑 가독성차이가 많이 나는것 같다. 성장했음을 느낀다. 
확실히 강욱님 리뷰와 강욱님 말씀대로 여러 코드들을 구경하는 습관을 들여보니 코테 코드짜는습관을 개선하는데 큰 도움이 된 것같다.

과거코드: 코드가 좀 더럽고, copy를 수행한다. (인구이동을 한번에 진행하므로)
현재코드: BFS로 인구이동 정보들을 받아온다음, 한번에 인구이동을 수행하기때문에 copy가 필요없다.

예전코드는 하단에..

Time Complexity
====  
O( N^2 * 2000(시뮬레이션횟수) )

Space Complexity (optional)
====  

Detailed Description
====  
```python
from collections import deque
import copy
import sys
input = sys.stdin.readline
n,L,R = map(int,input().split())
board = [list(map(int,input().split())) for _ in range(n)]
time = 0

def bfs(i,j):
    dy = [0,-1,0,1]
    dx = [-1,0,1,0]
    q = deque()
    visit[i][j] = 1
    q.append([i,j])
    target = [[i,j]]
    while q :
        y,x = q.popleft()
        for i in range(4):
            ny = y+dy[i]
            nx = x+dx[i]
            if 0<=ny<n and 0<=nx<n and visit[ny][nx] == 0 and L<=abs(board[y][x]-board[ny][nx])<=R:
                q.append([ny,nx])
                visit[ny][nx] = 1
                target.append([ny,nx])
    return target # 인구이동 대상지역

while True :
    visit = [[0] * n for _ in range(n)]
    count = 0
    new_board = copy.deepcopy(board)
    for i in range(n):
        for j in range(n):
            if visit[i][j] == 0 :
                move = bfs(i,j) # 인구이동이 되는 타겟을 구하고, 횟수를 카운트한다. 횟수카운트가 0 이라면, 인구이동x 라는소리.
                if len(move) > 1 :
                    count+=1 # 인구이동횟수
                    sum = 0
                    for y,x in move :
                        sum+=board[y][x]
                    for y,x in move :
                        new_board[y][x] = sum//len(move)
    board = new_board
    if count == 0 :
        break
    else:
        time+=1
print(time)
```